### PR TITLE
Make cluster calculation work when clustered content is further down

### DIFF
--- a/clusterize.js
+++ b/clusterize.js
@@ -195,7 +195,7 @@
     },
     // get current cluster number
     getClusterNum: function () {
-      this.options.scroll_top = this.scroll_elem.scrollTop;
+      this.options.scroll_top = this.scroll_elem.scrollTop - this.content_elem.offsetTop;
       return Math.floor(this.options.scroll_top / (this.options.cluster_height - this.options.block_height)) || 0;
     },
     // generate empty row if no data provided


### PR DESCRIPTION
Let's say you have a page that is scrollable, with a screen or two (or more) of non-clustered content, followed by a massive list that you want to be clusterized (but not scrollable itself). This makes that work, by taking into account the offsetTop of the clustered content within the scrollable container, so that the correct cluster number is used.

I had this problem with my website, and found the solution in pull request #103 (thanks @vsesh for figuring it out). This version is based on the latest version of the library and has been simplified to only modify one line. Works like a charm on my site. 

Note, no minified version in this pull request.