### PR TITLE
Fix scroll progress percent

### DIFF
--- a/clusterize.js
+++ b/clusterize.js
@@ -129,7 +129,7 @@
       return rows.length;
     }
     self.getScrollProgress = function() {
-      return this.options.scroll_top / (rows.length * this.options.item_height) * 100 || 0;
+      return this.options.scroll_top / (self.scroll_elem.scrollHeight - self.scroll_elem.clientHeight) * 100 || 0;
     }
 
     var add = function(where, _new_rows) {


### PR DESCRIPTION
## Scroll percent fix
- The scroll progress was returning the wrong value when reach the bottom off element;
```javascript
   /* - */  return this.options.scroll_top / (rows.length * this.options.item_height) * 100 || 0;
   /* + */  return this.options.scroll_top / (self.scroll_elem.scrollHeight - self.scroll_elem.clientHeight) * 100 || 0;
```